### PR TITLE
[codex] Support 16KB page size bundles

### DIFF
--- a/APP_MAINTENANCE.md
+++ b/APP_MAINTENANCE.md
@@ -367,7 +367,7 @@ Flutter 앱 버전은 `pubspec.yaml`에서 관리합니다.
 이 문서를 작성한 시점의 버전:
 
 ```yaml
-version: 1.3.2+20
+version: 1.3.2+21
 ```
 
 별도 릴리즈 규칙이 생기기 전까지는 다음 기준을 사용합니다.
@@ -455,3 +455,18 @@ Play Console에서 versionCode 19가 `READ_MEDIA_IMAGES`와 `READ_MEDIA_VIDEO`�
 향후 사용자가 직접 기기 사진/동영상을 선택해 업로드하는 기능이 필요하면 broad
 media read 권한을 다시 추가하기보다 Android system photo picker 기반 접근을
 우선 검토합니다.
+
+### 2026-05-26: Google Play 16KB memory page size 대응
+
+Play Console에서 versionCode 20 업로드 시 16KB memory page size 미지원 오류가
+발생했습니다. 로컬 ELF load alignment는 16KB 이상이었지만, AAB에서 생성되는 APK의
+native library zip alignment를 위해 실제 적용되는 Android Gradle Plugin 버전도
+8.5.1 이상이어야 합니다.
+
+조치:
+
+- `android/settings.gradle`의 `com.android.application` plugin version을 `8.1.0`에서
+  `8.8.0`으로 업데이트.
+- `android/app/build.gradle`의 `ndkVersion`을 `28.0.13004108`로 명시.
+- `pubspec.yaml` build number를 `21`로 올려 Play Console에 새 AAB를 제출할 수 있게
+  함.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -16,7 +16,7 @@ if (keystorePropertiesFile.exists()) {
 android {
     namespace = "com.team.visioneer.prayu"
     compileSdk = 35
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "28.0.13004108"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.8.0" apply false
     id "org.jetbrains.kotlin.android" version "1.8.22" apply false
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: prayu_app
 description: "A new Flutter project."
 publish_to: "none"
-version: 1.3.2+20
+version: 1.3.2+21
 environment:
   sdk: "3.5.4"
 dependencies:


### PR DESCRIPTION
## Summary

- Update the Android Gradle Plugin used by the plugin DSL from `8.1.0` to `8.8.0`.
- Pin Android NDK to `28.0.13004108` for 16KB page-size compatible native builds.
- Bump the Android build number to `1.3.2+21` after Play Console rejected versionCode 20.
- Document the Play Console 16KB memory page size response.

## Why

Play Console rejected the versionCode 20 AAB with: "앱이 16KB 메모리 페이지 크기를 지원하지 않습니다." Google's guidance requires 16KB-compatible packaging/native libraries for Android 15+ target apps, and recommends AGP 8.5.1+ with NDK r28+.

## Validation

- `flutter analyze`
- `flutter test`
- `flutter clean && flutter build appbundle --release --build-name=1.3.2 --build-number=21`
- `bundletool dump config --bundle=build/app/outputs/bundle/release/app-release.aab` reports `PAGE_ALIGNMENT_16K`.
- Release manifest reports versionCode `21`, versionName `1.3.2`.

## Upload Artifact

Use `build/app/outputs/bundle/release/app-release.aab`.

SHA-256: `a081b57ee357a64884f9ba5afda39c0b8c5f7548ba8662e02c23697ca9e0d497`